### PR TITLE
Fix duplicate YAML keys in mic-facing.md breaking the build

### DIFF
--- a/src/content/apps/mic-facing.md
+++ b/src/content/apps/mic-facing.md
@@ -6,8 +6,6 @@ icon: /images/apps/micfacing/icon.png
 coverImage: /images/apps/micfacing/LiveListen.png
 backgroundVideo: ""
 appStoreUrl: https://apps.apple.com/us/app/mic-facing/id6767724761
-coverImage: /images/apps/micfacing/icon.png
-backgroundVideo: ""
 feedbackEmail: matt2harrington@gmail.com
 supportDescription: "Need help with Mic Facing? Whether you have questions about EQ presets, iCloud recording sync, on-device transcription, live translation, or external USB-C mic support, I'm here to help. Reach out and I'll get back to you as soon as possible."
 order: 4


### PR DESCRIPTION
The frontmatter had coverImage and backgroundVideo defined twice, which is invalid YAML and caused `astro build` to fail with "duplicated mapping key" on the deploy. Removed the stale duplicates so only the LiveListen.png cover and a single backgroundVideo remain.